### PR TITLE
Added FST Bank and Preset handling.

### DIFF
--- a/src/js80p.hpp
+++ b/src/js80p.hpp
@@ -60,6 +60,7 @@ namespace Constants {
     constexpr char const* PLUGIN_NAME = "JS80P";
     constexpr char const* PLUGIN_VERSION_STR = JS80P_TO_STRING(JS80P_VERSION_STR);
     constexpr int PLUGIN_VERSION_INT = JS80P_VERSION_INT;
+    constexpr size_t NO_OF_PROGRAMS = 128; // Most well implemented FST's from around 2010 have banks with this size...
 
     constexpr Integer PARAM_NAME_MAX_LENGTH = 8;
 

--- a/src/plugin/fst/plugin.hpp
+++ b/src/plugin/fst/plugin.hpp
@@ -20,6 +20,7 @@
 #define JS80P__PLUGIN__FST__PLUGIN_HPP
 
 #include <string>
+#include <array>
 
 #include <fst/fst.h>
 
@@ -37,6 +38,7 @@ class FstPlugin
     public:
         static constexpr int OUT_CHANNELS = (int)Synth::OUT_CHANNELS;
         static constexpr VstInt32 VERSION = JS80P::Constants::PLUGIN_VERSION_INT;
+        static constexpr size_t NO_OF_PROGRAMS = JS80P::Constants::NO_OF_PROGRAMS;
 
         static AEffect* create_instance(
             audioMasterCallback const host_callback,
@@ -98,8 +100,15 @@ class FstPlugin
             float** samples
         ) noexcept;
 
-        VstIntPtr get_chunk(void** chunk) noexcept;
-        void set_chunk(void const* chunk, VstIntPtr const size) noexcept;
+        VstIntPtr get_chunk(void** chunk, bool isPreset) noexcept;
+        void set_chunk(void const* chunk, VstIntPtr const size, bool isPreset) noexcept;
+
+        VstIntPtr get_program() const noexcept;
+        void set_program(size_t index) noexcept;
+
+        bool get_program_name_indexed(char* name, size_t index) noexcept;
+        void get_program_name(char* name) noexcept;
+        void set_program_name(const char* name);
 
         void open_gui(GUI::PlatformWidget parent_window);
         void gui_idle();
@@ -108,6 +117,9 @@ class FstPlugin
         Synth synth;
 
     private:
+        void import_serialized_program(const std::string& serialized_program) noexcept;
+        void get_program_name_short(char* name, size_t index) noexcept;
+
         static constexpr Integer ROUND_MASK = 0x7fff;
 
         Sample const* const* render_next_round(VstInt32 sample_count) noexcept;
@@ -119,7 +131,11 @@ class FstPlugin
         ERect window_rect;
         Integer round;
         GUI* gui;
-        std::string serialized;
+        std::array<std::string, NO_OF_PROGRAMS> serialized_programs;
+        std::array<std::string, NO_OF_PROGRAMS> serialized_program_names;
+        size_t current_program_index{0};
+        bool store_state_of_previous_program_in_set_program{true};
+        std::string serialized_bank;
 };
 
 }

--- a/src/serializer.cpp
+++ b/src/serializer.cpp
@@ -29,11 +29,14 @@
 namespace JS80P
 {
 
+const std::string Serializer::PROG_NAME_LINE_TAG{"Name = "};
+
 std::string Serializer::serialize(Synth const* synth) noexcept
 {
     constexpr size_t line_size = 128;
     char line[line_size];
     std::string serialized("[js80p]\r\n");
+    serialized += PROG_NAME_LINE_TAG + synth->get_program_name() + "\r\n";
 
     for (int i = 0; i != Synth::ParamId::MAX_PARAM_ID; ++i) {
         Synth::ParamId const param_id = (Synth::ParamId)i;
@@ -84,6 +87,7 @@ Synth::ControllerId Serializer::float_to_controller_id(
 
 void Serializer::import(Synth* synth, std::string const& serialized) noexcept
 {
+    synth->set_program_name("Init");
     reset_all_params_to_default(synth);
     std::vector<std::string>* lines = parse_lines(serialized);
     process_lines(synth, lines);
@@ -290,6 +294,10 @@ void Serializer::process_line(Synth* synth, std::string const line) noexcept
             || !parse_number(it, end, number)
             || !skipping_remaining_whitespace_or_comment_reaches_the_end(it, end)
     ) {
+        auto findNameIndex{line.find(PROG_NAME_LINE_TAG)};
+        if (std::string::npos != findNameIndex) {
+            synth->set_program_name(line.substr(PROG_NAME_LINE_TAG.length()));
+        }
         return;
     }
 

--- a/src/serializer.hpp
+++ b/src/serializer.hpp
@@ -33,6 +33,7 @@ class Serializer
 {
     public:
         static constexpr Integer MAX_SIZE = 256 * 1024;
+        static const std::string PROG_NAME_LINE_TAG;
 
         static std::string serialize(Synth const* synth) noexcept;
 

--- a/src/synth.cpp
+++ b/src/synth.cpp
@@ -754,6 +754,15 @@ void Synth::push_message(
     messages.push(message);
 }
 
+const std::string& Synth::get_program_name() const noexcept
+{
+    return program_name;
+}
+
+void Synth::set_program_name(const std::string& name)
+{
+    program_name = name;
+}
 
 std::string Synth::get_param_name(ParamId const param_id) const noexcept
 {

--- a/src/synth.hpp
+++ b/src/synth.hpp
@@ -561,6 +561,9 @@ class Synth : public Midi::EventHandler, public SignalProducer
 
         void process_messages() noexcept;
 
+        const std::string& get_program_name() const noexcept;
+        void set_program_name(const std::string&);
+
         std::string get_param_name(ParamId const param_id) const noexcept;
         ParamId get_param_id(std::string const name) const noexcept;
         void get_param_id_hash_table_statistics(
@@ -894,6 +897,7 @@ class Synth : public Midi::EventHandler, public SignalProducer
         Carrier* carriers[POLYPHONY];
         Integer next_voice;
         Midi::Note previous_note;
+        std::string program_name{"Init"};
 
     public:
         MidiController* const* const midi_controllers;


### PR DESCRIPTION
The 'Synth' class got one additional 'pseudo'-parameter called 'name'.
It defaults to 'Init' and gets serialized/imported alongside the regular synth parameters in the 'serialize' and 'import' functions of the 'Serializer' class.
The FST plugin code has most of the relevant changes:
'set_chunk' and 'get_chunk' got an additional parameter indicating if only a preset's or the whole bank's state should get restored/stored.
There also functions for handling opcodes 'effSetProgram', 'effGetProgram', 'effSetProgramName', 'effGetProgramName' and 'effGetProgramNameIndexed' got introduced.
 I made js80p support banks of 128 presets - as this is what most FST 2 plugins have.
 This means that the FST plugin code needs to keep an array of 128 serialized strings representing those 128 presets.
 It also keeps an array of 128 preset names (each an empty string initially, but if accessed and still empty then get parsed from the respective preset's serialized string).
 The code shouldn't affect the VST3 version at all (except that also the preset name 'Init' would be serialized) and also all other code not related to bank and preset handling is untouched.
 I guess code in 'serialize' and 'import' of the 'Serialize' class could be adjusted to make it work more like the other code there, but because I couldn't really debug, I didn't do that.
 I tested 'only' the 64 bit Windows version with Herman Seib's 'savihost_64.exe' and with 'real' DAW  'EXT64 beta 1' (https://www.xtsware.com/?page_id=297).
 
I didn't even try to give the synth the ability to name a preset from its GUI, as this is not a requirement for the functionality of the FST bank and preset handling - but this is something which would be possible now.