### PR TITLE
Add loongarch64 support

### DIFF
--- a/lib/fst/fst.h
+++ b/lib/fst/fst.h
@@ -111,7 +111,7 @@
 #define VSTCALLBACK
 
  /* t_fstPtrInt: pointer sized int */
-#if defined(_WIN32) && (defined(__x86_64__) || defined (_M_X64))
+#if defined(_WIN32) && (defined(__x86_64__) || defined (_M_X64) || defined(__loongarch_lp64))
 typedef long long t_fstPtrInt;
 #else
 typedef long t_fstPtrInt;

--- a/lib/vst3sdk/base/source/fdebug.cpp
+++ b/lib/vst3sdk/base/source/fdebug.cpp
@@ -230,7 +230,7 @@ void FDebugBreak (const char* format, ...)
 #elif SMTG_OS_MACOS && __arm64__
 			raise (SIGSTOP);
 
-#elif __ppc64__ || __ppc__ || __arm__
+#elif __ppc64__ || __ppc__ || __arm__ || __loongarch_lp64
 			kill (getpid (), SIGINT);
 #elif __i386__ || __x86_64__
 			{

--- a/make/linux-loong64-gpp.mk
+++ b/make/linux-loong64-gpp.mk
@@ -17,13 +17,13 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 ###############################################################################
 
-INSTRUCTION_SET = none
+INSTRUCTION_SET = lsx
 
 LIB_PATH ?= $(BUILD_DIR)/lib64
 SYS_LIB_PATH ?= /usr/lib/loong64-linux-gnu
 SUFFIX = loong64
-OBJ_GUI_BFDNAME = elf64-loongarch64
-OBJ_GUI_BFDARCH = loong
+OBJ_GUI_BFDNAME = elf64-loongarch
+OBJ_GUI_BFDARCH = loongarch64
 ARCH_CXXFLAGS = -march=loongarch64 -mabi=lp64d
 ARCH_LFLAGS = -L$(LIB_PATH)
 

--- a/make/linux-loong64-gpp.mk
+++ b/make/linux-loong64-gpp.mk
@@ -1,0 +1,30 @@
+###############################################################################
+# This file is part of JS80P, a synthesizer plugin.
+# Copyright (C) 2023, 2024  Attila M. Magyar
+# Copyright (C) 2023  @aimixsaka (https://github.com/aimixsaka/)
+#
+# JS80P is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# JS80P is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+###############################################################################
+
+INSTRUCTION_SET = none
+
+LIB_PATH ?= $(BUILD_DIR)/lib64
+SYS_LIB_PATH ?= /usr/lib/loong64-linux-gnu
+SUFFIX = loong64
+OBJ_GUI_BFDNAME = elf64-loongarch64
+OBJ_GUI_BFDARCH = loong
+ARCH_CXXFLAGS = -march=loongarch64 -mabi=lp64d
+ARCH_LFLAGS = -L$(LIB_PATH)
+
+include make/linux-gpp.mk

--- a/scripts/build_and_deploy.sh
+++ b/scripts/build_and_deploy.sh
@@ -48,7 +48,7 @@ main()
 
     if [[ "$plugin_type$target_os$arch" = "" ]]
     then
-        echo "Usage: $0 fst|vst3 linux|windows x86|x86_64|riscv64 [avx|sse2|none]" >&2
+        echo "Usage: $0 fst|vst3 linux|windows x86|x86_64|riscv64|loongarch64 [avx|sse2|lsx|none]" >&2
         return 1
     fi
 
@@ -62,8 +62,9 @@ main()
     case "$arch" in
         "x86") target_platform="i686" ;;
         "x86_64"|"riscv64") target_platform="$arch" ;;
+        "loongarch64") target_platform="loong64"
         *)
-            echo "Unknown architecture: \"$arch\" - should be either \"x86\" or \"x86_64\" or \"riscv64\"" >&2
+            echo "Unknown architecture: \"$arch\" - should be either \"x86\" or \"x86_64\" or \"riscv64\" or \"loongarch64\"" >&2
             return 1
             ;;
     esac
@@ -94,16 +95,18 @@ main()
     TARGET_PLATFORM="$target_platform" INSTRUCTION_SET="$instruction_set" make "$plugin_type"
 
     case "$target_os-$plugin_type-$arch" in
-        "linux-fst-x86_64")     replace_in_dir "$built_plugin" $FST_DIRS_LINUX_64 ;;
-        "linux-vst3-x86_64")    replace_in_dir "$built_plugin" $VST3_DIRS_LINUX_64 ;;
-        "linux-fst-riscv64")    replace_in_dir "$built_plugin" $VST3_DIRS_LINUX_64 ;;
-        "linux-vst3-riscv64")   replace_in_dir "$built_plugin" $VST3_DIRS_LINUX_64 ;;
-        "windows-fst-x86_64")   replace_in_dir "$built_plugin" $FST_DIRS_WINE_64 ;;
-        "windows-vst3-x86_64")  replace_in_dir "$built_plugin" $VST3_DIRS_WINE_64 ;;
-        "linux-fst-x86")        replace_in_dir "$built_plugin" $FST_DIRS_LINUX_32 ;;
-        "linux-vst3-x86")       replace_in_dir "$built_plugin" $VST3_DIRS_LINUX_32 ;;
-        "windows-fst-x86")      replace_in_dir "$built_plugin" $FST_DIRS_WINE_32 ;;
-        "windows-vst3-x86")     replace_in_dir "$built_plugin" $VST3_DIRS_WINE_32 ;;
+        "linux-fst-x86_64")         replace_in_dir "$built_plugin" $FST_DIRS_LINUX_64 ;;
+        "linux-vst3-x86_64")        replace_in_dir "$built_plugin" $VST3_DIRS_LINUX_64 ;;
+        "linux-fst-riscv64")        replace_in_dir "$built_plugin" $VST3_DIRS_LINUX_64 ;;
+        "linux-vst3-riscv64")       replace_in_dir "$built_plugin" $VST3_DIRS_LINUX_64 ;;
+        "linux-fst-loongarch64")    replace_in_dir "$built_plugin" $VST3_DIRS_LINUX_64 ;;
+        "linux-vst3-loongarch64")   replace_in_dir "$built_plugin" $VST3_DIRS_LINUX_64 ;;
+        "windows-fst-x86_64")       replace_in_dir "$built_plugin" $FST_DIRS_WINE_64 ;;
+        "windows-vst3-x86_64")      replace_in_dir "$built_plugin" $VST3_DIRS_WINE_64 ;;
+        "linux-fst-x86")            replace_in_dir "$built_plugin" $FST_DIRS_LINUX_32 ;;
+        "linux-vst3-x86")           replace_in_dir "$built_plugin" $VST3_DIRS_LINUX_32 ;;
+        "windows-fst-x86")          replace_in_dir "$built_plugin" $FST_DIRS_WINE_32 ;;
+        "windows-vst3-x86")         replace_in_dir "$built_plugin" $VST3_DIRS_WINE_32 ;;
     esac
 
     echo "SUCCESS" >&2

--- a/scripts/gen_download_links.sh
+++ b/scripts/gen_download_links.sh
@@ -86,6 +86,12 @@ get_arch()
         return
     fi
 
+    if [[ "$file_name" =~ loongarch64 ]]
+    then
+        echo "64"
+        return
+    fi
+
     echo "32"
 }
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -440,7 +440,7 @@ package_vst3_bundle()
             copy_vst3 "$version_as_file_name" "linux-x86_64-avx" "$vst3_base_dir" "x86_64-linux" "js80p.so"
             copy_vst3 "$version_as_file_name" "windows-x86_64-avx" "$vst3_base_dir" "x86_64-win" "js80p.vst3"
             ;;
-        "none")
+        "lsx")
             copy_vst3 "$version_as_file_name" "linux-loong64-lsx" "$vst3_base_dir" "loong64-linux" "js80p.so"
             ;;
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -24,7 +24,7 @@ set -e
 set -u
 set -o pipefail
 
-TARGET_PLATFORMS="x86_64-w64-mingw32:avx x86_64-w64-mingw32:sse2 i686-w64-mingw32:sse2 x86_64-gpp:avx x86_64-gpp:sse2 i686-gpp:sse2 riscv64-gpp:none rloongarch64-gpp:none"
+TARGET_PLATFORMS="x86_64-w64-mingw32:avx x86_64-w64-mingw32:sse2 i686-w64-mingw32:sse2 x86_64-gpp:avx x86_64-gpp:sse2 i686-gpp:sse2 riscv64-gpp:none loongarch64-gpp:lsx"
 PLUGIN_TYPES="fst vst3"
 TEXT_FILES="LICENSE.txt README.txt NEWS.txt"
 DIST_DIR_BASE="dist"
@@ -197,6 +197,14 @@ main()
         log "Skipping VST 3 bundle for RISC-V 64"
     fi
 
+    if [[ "$target_platforms" =~ loong64-gpp:lsx ]]
+    then
+        log "Bulding VST 3 bundle for loongarch64"
+        package_vst3_bundle "$version_as_file_name" "none"
+    else
+        log "Skipping VST 3 bundle for loongarch64"
+    fi
+
     log "Done"
 }
 
@@ -266,7 +274,7 @@ call_make_for_build_platform()
     case "$build_platform" in
         "x86_64")       call_make "x86_64-w64-mingw32" "avx" "$@" ;;
         "riscv64")      call_make "riscv64-gpp" "none" "$@" ;;
-        "loongarch64")  call_make "loong64-gpp" "none" "$@" ;;
+        "loongarch64")  call_make "loong64-gpp" "lsx" "$@" ;;
         *) error "Unsupported build platform: $uname" ;;
     esac
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -24,7 +24,7 @@ set -e
 set -u
 set -o pipefail
 
-TARGET_PLATFORMS="x86_64-w64-mingw32:avx x86_64-w64-mingw32:sse2 i686-w64-mingw32:sse2 x86_64-gpp:avx x86_64-gpp:sse2 i686-gpp:sse2 riscv64-gpp:none"
+TARGET_PLATFORMS="x86_64-w64-mingw32:avx x86_64-w64-mingw32:sse2 i686-w64-mingw32:sse2 x86_64-gpp:avx x86_64-gpp:sse2 i686-gpp:sse2 riscv64-gpp:none rloongarch64-gpp:none"
 PLUGIN_TYPES="fst vst3"
 TEXT_FILES="LICENSE.txt README.txt NEWS.txt"
 DIST_DIR_BASE="dist"
@@ -264,8 +264,9 @@ call_make_for_build_platform()
     shift
 
     case "$build_platform" in
-        "x86_64")   call_make "x86_64-w64-mingw32" "avx" "$@" ;;
-        "riscv64")  call_make "riscv64-gpp" "none" "$@" ;;
+        "x86_64")       call_make "x86_64-w64-mingw32" "avx" "$@" ;;
+        "riscv64")      call_make "riscv64-gpp" "none" "$@" ;;
+        "loongarch64")  call_make "loong64-gpp" "none" "$@" ;;
         *) error "Unsupported build platform: $uname" ;;
     esac
 }
@@ -431,6 +432,10 @@ package_vst3_bundle()
             copy_vst3 "$version_as_file_name" "linux-x86_64-avx" "$vst3_base_dir" "x86_64-linux" "js80p.so"
             copy_vst3 "$version_as_file_name" "windows-x86_64-avx" "$vst3_base_dir" "x86_64-win" "js80p.vst3"
             ;;
+        "none")
+            copy_vst3 "$version_as_file_name" "linux-loong64-lsx" "$vst3_base_dir" "loong64-linux" "js80p.so"
+            ;;
+
         "none")
             copy_vst3 "$version_as_file_name" "linux-riscv64-none" "$vst3_base_dir" "riscv64-linux" "js80p.so"
             ;;

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -200,7 +200,7 @@ main()
     if [[ "$target_platforms" =~ loong64-gpp:lsx ]]
     then
         log "Bulding VST 3 bundle for loongarch64"
-        package_vst3_bundle "$version_as_file_name" "none"
+        package_vst3_bundle "$version_as_file_name" "lsx"
     else
         log "Skipping VST 3 bundle for loongarch64"
     fi


### PR DESCRIPTION
[LoongArch](https://docs.kernel.org/arch/loongarch/introduction.html) is a new RISC ISA developed by loongson. There are already a lot of [community support and testing](https://www.phoronix.com/search/LoongArch) about it.

Hello,I'm a green hand and working on porting archlinux to loongarch64. Would you please to review my changes and support loongarch64? Many thanks.

Although there are some compile dependencies lacked,I succeed to compile it though PKGBUILD by [patch](https://github.com/lcpu-club/loongarch-packages/compare/master...YHStar:loongarch-packages:master). I found there is no arch changes. And if my pr has some unnecessary changes ,tell me I will do as soon ,thx :)