### PR TITLE
Fix format for loongarch64

### DIFF
--- a/make/linux-loongarch64-gpp.mk
+++ b/make/linux-loongarch64-gpp.mk
@@ -19,8 +19,8 @@
 INSTRUCTION_SET = lsx
 
 LIB_PATH ?= $(BUILD_DIR)/lib64
-SYS_LIB_PATH ?= /usr/lib/loong64-linux-gnu
-SUFFIX = loong64
+SYS_LIB_PATH ?= /usr/lib/loongarch64-linux-gnu
+SUFFIX = loongarch64
 OBJ_GUI_BFDNAME = elf64-loongarch
 OBJ_GUI_BFDARCH = loongarch64
 ARCH_CXXFLAGS = -march=loongarch64 -mabi=lp64d


### PR DESCRIPTION
Hello! Thank you for taking my PR when I was a green hand. But now I find a problem in it when I launch a PR to 
[DPF - DISTRHO Plugin Framework](https://github.com/DISTRHO/DPF/pull/476) .From [Steinberg VST3 developer portal](https://steinbergmedia.github.io/vst3_dev_portal/pages/Technical+Documentation/Locations+Format/Plugin+Format.html#for-the-linux-platform), I learn that the plugin should be named loongarch64-linux. I'm sorry for my previous bug PR, and hope to fix it

![图片](https://github.com/user-attachments/assets/3a86573a-9317-4df0-b783-a396dcb1aabb)
